### PR TITLE
fix: Capitalize discord button text to 'Discord'

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -145,7 +145,7 @@
             </a>
             <a class="button" href="https://discord.com/channels/811472318080483358/811472319876562989" rel="noopener" title="discord">
                 <span class="button-inner">
-                    discord&nbsp;
+                    Discord&nbsp;
                     <svg fill="none" shape-rendering="geometricPrecision" stroke="currentColor" stroke-linecap="round"
                         stroke-linejoin="round" stroke-width="2.5" viewBox="0 0 24 24" height="14" width="14">
                         <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"></path>


### PR DESCRIPTION
Other buttons are in initial caps except this button.